### PR TITLE
Fix platform version extraction from runtime.platform.path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-arduino-sketch-vault",
   "displayName": "Arduino Sketch Vault",
   "description": "Logs Arduino board configuration changes (FQBN, Upload Speed, etc.) to help track your project settings",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "repository": "https://github.com/devista-consulting/arduino-sketch-vault.git",
   "publisher": "devista-consulting",

--- a/src/services/profile-service.ts
+++ b/src/services/profile-service.ts
@@ -3,6 +3,7 @@ import type { ArduinoContext, BoardDetails, Profile, SketchYamlStructure } from 
 import { SketchYamlService } from './sketch-yaml-service';
 import { BoardSyncService } from './board-sync-service';
 import { buildCompleteFqbn, formatFqbnSummary, extractPlatformId, formatPlatformString } from '../utils/fqbn-utils';
+import { getPlatformVersion } from '../utils/version-utils';
 import { DEFAULT_PROFILE_NAME, PROFILE_NAME_PATTERN, PROFILE_NAME_ERROR } from '../utils/constants';
 
 export class ProfileService {
@@ -395,8 +396,8 @@ export class ProfileService {
     // Extract platform from FQBN
     const platformId = extractPlatformId(fqbn);
 
-    // Try to get platform version from buildProperties
-    const platformVersion = boardDetails?.buildProperties?.['version'];
+    // Get platform version from runtime.platform.path (most reliable source)
+    const platformVersion = getPlatformVersion(boardDetails?.buildProperties, platformId);
 
     // Build platform string with version if available
     const platformString = formatPlatformString(platformId, platformVersion);

--- a/src/services/sketch-yaml-service.ts
+++ b/src/services/sketch-yaml-service.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import type { ArduinoContext, BoardDetails, SketchYamlProfile, SketchYamlStructure } from '../types';
 import { buildCompleteFqbn, extractPlatformId, formatPlatformString } from '../utils/fqbn-utils';
+import { getPlatformVersion } from '../utils/version-utils';
 import { SKETCH_YAML_FILENAME, DEFAULT_PROFILE_NAME, CONFIG_AUTO_UPDATE_SKETCH_YAML } from '../utils/constants';
 
 export class SketchYamlService {
@@ -118,8 +119,8 @@ export class SketchYamlService {
     // Extract platform from FQBN
     const platformId = extractPlatformId(fqbn);
 
-    // Try to get platform version from buildProperties
-    const platformVersion = boardDetails?.buildProperties?.['version'];
+    // Get platform version from runtime.platform.path (most reliable source)
+    const platformVersion = getPlatformVersion(boardDetails?.buildProperties, platformId);
 
     // Build platform string with version if available
     const platformString = formatPlatformString(platformId, platformVersion);

--- a/src/test/suite/unit/utils/version-utils.test.ts
+++ b/src/test/suite/unit/utils/version-utils.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Unit tests for version extraction utilities
+ */
+
+import {
+  extractPlatformVersionFromPath,
+  getPlatformVersion
+} from '../../../../utils/version-utils';
+
+describe('Version Utilities', () => {
+  describe('extractPlatformVersionFromPath', () => {
+    describe('Standard Paths', () => {
+      it('should extract version from ESP32 platform path (macOS)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/Users/tibor/Library/Arduino15/packages/arduino/hardware/esp32/2.0.18-arduino.5'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:esp32');
+        expect(version).toBe('2.0.18-arduino.5');
+      });
+
+      it('should extract version from ESP32 platform path (Linux)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/home/user/.arduino15/packages/esp32/hardware/esp32/3.0.7'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'esp32:esp32');
+        expect(version).toBe('3.0.7');
+      });
+
+      it('should extract version from ESP32 platform path (Windows)', () => {
+        // Arduino CLI normalizes paths to forward slashes even on Windows
+        const buildProperties = {
+          'runtime.platform.path': 'C:/Users/User/AppData/Local/Arduino15/packages/esp32/hardware/esp32/2.0.17'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'esp32:esp32');
+        expect(version).toBe('2.0.17');
+      });
+
+      it('should extract version from Arduino AVR platform path', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/Users/user/Library/Arduino15/packages/arduino/hardware/avr/1.8.6'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:avr');
+        expect(version).toBe('1.8.6');
+      });
+
+      it('should extract version from Arduino SAMD platform path', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/home/user/.arduino15/packages/arduino/hardware/samd/1.8.13'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:samd');
+        expect(version).toBe('1.8.13');
+      });
+
+      it('should extract version from Adafruit SAMD platform path', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/Users/user/Library/Arduino15/packages/adafruit/hardware/samd/1.7.14'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'adafruit:samd');
+        expect(version).toBe('1.7.14');
+      });
+
+      it('should extract version from STM32 platform path', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/home/user/.arduino15/packages/STMicroelectronics/hardware/stm32/2.8.1'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'STMicroelectronics:stm32');
+        expect(version).toBe('2.8.1');
+      });
+
+      it('should extract version from RP2040 platform path', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/Users/user/Library/Arduino15/packages/rp2040/hardware/rp2040/4.2.1'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'rp2040:rp2040');
+        expect(version).toBe('4.2.1');
+      });
+    });
+
+    describe('Version Formats', () => {
+      it('should extract simple semantic version', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBe('1.2.3');
+      });
+
+      it('should extract version with pre-release tag', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/2.0.0-rc.1'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBe('2.0.0-rc.1');
+      });
+
+      it('should extract version with build metadata', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.5.0+build.20241022'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBe('1.5.0+build.20241022');
+      });
+
+      it('should extract version with custom suffix (arduino style)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/arduino/hardware/esp32/2.0.18-arduino.5'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:esp32');
+        expect(version).toBe('2.0.18-arduino.5');
+      });
+
+      it('should extract version with underscores', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1_2_3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBe('1_2_3');
+      });
+    });
+
+    describe('Edge Cases', () => {
+      it('should return undefined when buildProperties is undefined', () => {
+        const version = extractPlatformVersionFromPath(undefined, 'arduino:esp32');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when runtime.platform.path is missing', () => {
+        const buildProperties = {
+          'version': '1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:esp32');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when runtime.platform.path is empty', () => {
+        const buildProperties = {
+          'runtime.platform.path': ''
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:esp32');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when platform ID is malformed (no colon)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'invalid');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when platform ID has empty vendor', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, ':arch');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when platform ID has empty arch', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when path does not contain platform pattern', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/completely/different/path/structure/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when path has vendor mismatch', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/wrongvendor/hardware/arch/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when path has arch mismatch', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/wrongarch/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when path ends at arch (no version)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when path ends with trailing slash (no version)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBeUndefined();
+      });
+    });
+
+    describe('Path with Subdirectories', () => {
+      it('should extract version only (not include subdirectories)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.2.3/cores/arduino'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBe('1.2.3');
+      });
+
+      it('should extract version from middle of longer path', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/long/path/to/packages/vendor/hardware/arch/5.6.7/variants/board'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'vendor:arch');
+        expect(version).toBe('5.6.7');
+      });
+    });
+
+    describe('Case Sensitivity', () => {
+      it('should match case-sensitively (vendor mismatch)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/Arduino/hardware/esp32/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:esp32');
+        expect(version).toBeUndefined();
+      });
+
+      it('should match case-sensitively (arch mismatch)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/arduino/hardware/ESP32/1.2.3'
+        };
+
+        const version = extractPlatformVersionFromPath(buildProperties, 'arduino:esp32');
+        expect(version).toBeUndefined();
+      });
+    });
+  });
+
+  describe('getPlatformVersion', () => {
+    describe('Successful Path Extraction', () => {
+      it('should return version from runtime.platform.path when available', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/arduino/hardware/esp32/2.0.18-arduino.5',
+          'version': 'v2.0.17-arduino.5'  // Outdated/invalid
+        };
+
+        const version = getPlatformVersion(buildProperties, 'arduino:esp32');
+        expect(version).toBe('2.0.18-arduino.5');
+      });
+
+      it('should prefer path over version property even when both valid', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/3.0.0',
+          'version': '2.0.0'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'vendor:arch');
+        expect(version).toBe('3.0.0');
+      });
+    });
+
+    describe('Fallback to Version Property', () => {
+      it('should fallback to version property when path is missing', () => {
+        const buildProperties = {
+          'version': '1.8.6'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'arduino:avr');
+        expect(version).toBe('1.8.6');
+      });
+
+      it('should fallback to version property when path extraction fails', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/invalid/path/structure',
+          'version': '2.0.0'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'vendor:arch');
+        expect(version).toBe('2.0.0');
+      });
+
+      it('should fallback to version property when platform ID is malformed', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.2.3',
+          'version': '5.0.0'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'invalid');
+        expect(version).toBe('5.0.0');
+      });
+
+      it('should fallback even with invalid version property format', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/invalid/path',
+          'version': 'v1.2.3'  // Invalid format (v prefix)
+        };
+
+        const version = getPlatformVersion(buildProperties, 'vendor:arch');
+        expect(version).toBe('v1.2.3');
+      });
+    });
+
+    describe('Both Undefined', () => {
+      it('should return undefined when buildProperties is undefined', () => {
+        const version = getPlatformVersion(undefined, 'arduino:esp32');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when both path and version are missing', () => {
+        const buildProperties = {
+          'some.other.property': 'value'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'arduino:esp32');
+        expect(version).toBeUndefined();
+      });
+
+      it('should return undefined when path extraction fails and version is missing', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/invalid/path'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'vendor:arch');
+        expect(version).toBeUndefined();
+      });
+    });
+
+    describe('Real-World Scenarios', () => {
+      it('should handle ESP32 platform with correct version from path', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/Users/tibor/Library/Arduino15/packages/arduino/hardware/esp32/2.0.18-arduino.5',
+          'version': 'v2.0.17-arduino.5',  // Outdated with v prefix
+          'build.board': 'ESP32_DEV',
+          'build.f_cpu': '240000000L'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'arduino:esp32');
+        expect(version).toBe('2.0.18-arduino.5');
+      });
+
+      it('should handle Arduino AVR platform', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/home/user/.arduino15/packages/arduino/hardware/avr/1.8.6',
+          'version': '1.8.6',
+          'build.board': 'AVR_UNO'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'arduino:avr');
+        expect(version).toBe('1.8.6');
+      });
+
+      it('should handle third-party platform (Adafruit SAMD)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/Users/user/Library/Arduino15/packages/adafruit/hardware/samd/1.7.14',
+          'version': '1.7.14'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'adafruit:samd');
+        expect(version).toBe('1.7.14');
+      });
+
+      it('should handle platform without version in buildProperties', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/esp32/hardware/esp32/3.0.7',
+          'build.board': 'ESP32S3_DEV'
+        };
+
+        const version = getPlatformVersion(buildProperties, 'esp32:esp32');
+        expect(version).toBe('3.0.7');
+      });
+    });
+
+    describe('Priority Testing', () => {
+      it('should use path version even when version property is more recent (trust path)', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.0.0',
+          'version': '2.0.0'  // Higher version in property
+        };
+
+        const version = getPlatformVersion(buildProperties, 'vendor:arch');
+        expect(version).toBe('1.0.0');
+      });
+
+      it('should use path version even when version property looks cleaner', () => {
+        const buildProperties = {
+          'runtime.platform.path': '/packages/vendor/hardware/arch/1.0.0-beta.1',
+          'version': '1.0.0'  // Cleaner version in property
+        };
+
+        const version = getPlatformVersion(buildProperties, 'vendor:arch');
+        expect(version).toBe('1.0.0-beta.1');
+      });
+    });
+  });
+});

--- a/src/utils/fqbn-utils.ts
+++ b/src/utils/fqbn-utils.ts
@@ -107,9 +107,17 @@ export function extractPlatformId(fqbn: string): string {
 
 /**
  * Formats platform string with version
+ *
+ * Version should be extracted from runtime.platform.path using getPlatformVersion()
+ * which contains the actual installed version (e.g., "2.0.18-arduino.5") rather than
+ * the unreliable version property from platform.txt which may contain invalid formats
+ * like "v2.0.17-arduino.5" or outdated versions.
+ *
  * @param platformId Platform ID (vendor:arch)
- * @param version Optional platform version
+ * @param version Optional platform version (should come from runtime.platform.path)
  * @returns Formatted platform string
+ * @see getPlatformVersion in version-utils.ts
+ * @see https://github.com/devista-consulting/arduino-sketch-vault/issues/1
  */
 export function formatPlatformString(platformId: string, version?: string): string {
   return version ? `${platformId} (${version})` : platformId;

--- a/src/utils/version-utils.ts
+++ b/src/utils/version-utils.ts
@@ -1,0 +1,87 @@
+/**
+ * Utility functions for extracting platform version information
+ */
+
+/**
+ * Extracts the platform version from runtime.platform.path
+ *
+ * The runtime.platform.path contains the full installation path like:
+ * /Users/tibor/Library/Arduino15/packages/arduino/hardware/esp32/2.0.18-arduino.5
+ *
+ * This function extracts the version (last part of the path) which represents
+ * the actual installed version, unlike platform.txt which may contain outdated
+ * or invalid version strings.
+ *
+ * @param buildProperties - Board build properties object
+ * @param platformId - Platform identifier (e.g., "esp32:esp32", "arduino:avr")
+ * @returns Platform version string or undefined if not found
+ *
+ * @example
+ * const version = extractPlatformVersionFromPath(buildProperties, "arduino:esp32");
+ * // Returns: "2.0.18-arduino.5"
+ */
+export function extractPlatformVersionFromPath(
+  buildProperties: Record<string, string> | undefined,
+  platformId: string
+): string | undefined {
+  if (!buildProperties) {
+    return undefined;
+  }
+
+  const runtimePlatformPath = buildProperties['runtime.platform.path'];
+  if (!runtimePlatformPath) {
+    return undefined;
+  }
+
+  // Extract vendor:arch from platformId (e.g., "esp32:esp32" or "arduino:avr")
+  const [vendor, arch] = platformId.split(':');
+  if (!vendor || !arch) {
+    return undefined;
+  }
+
+  // The path structure is: /path/to/packages/{vendor}/hardware/{arch}/{version}/
+  // Example: /Users/tibor/Library/Arduino15/packages/arduino/hardware/esp32/2.0.18-arduino.5
+
+  // Build the pattern to match: /{vendor}/hardware/{arch}/
+  const pattern = `/${vendor}/hardware/${arch}/`;
+  const patternIndex = runtimePlatformPath.indexOf(pattern);
+
+  if (patternIndex === -1) {
+    return undefined;
+  }
+
+  // Extract everything after the pattern
+  const afterPattern = runtimePlatformPath.substring(patternIndex + pattern.length);
+
+  // The version is the first directory after the pattern (before next /)
+  const versionMatch = afterPattern.match(/^([^/]+)/);
+
+  if (!versionMatch) {
+    return undefined;
+  }
+
+  return versionMatch[1];
+}
+
+/**
+ * Gets platform version from buildProperties, trying runtime.platform.path first,
+ * falling back to the version property if needed.
+ *
+ * @param buildProperties - Board build properties object
+ * @param platformId - Platform identifier (e.g., "esp32:esp32", "arduino:avr")
+ * @returns Platform version string or undefined if not found
+ */
+export function getPlatformVersion(
+  buildProperties: Record<string, string> | undefined,
+  platformId: string
+): string | undefined {
+  // Try to extract from runtime.platform.path (most reliable)
+  const pathVersion = extractPlatformVersionFromPath(buildProperties, platformId);
+
+  if (pathVersion) {
+    return pathVersion;
+  }
+
+  // Fallback to version property (may be outdated/invalid)
+  return buildProperties?.['version'];
+}


### PR DESCRIPTION
Resolves issue where platform version was extracted from unreliable platform.txt which contained invalid formats (v prefix) and outdated versions. Now extracts version directly from the filesystem path in runtime.platform.path property.

Changes:
- Add version-utils.ts with extractPlatformVersionFromPath() and getPlatformVersion()
- Update ProfileService to use reliable version extraction
- Update SketchYamlService to use reliable version extraction
- Add 43 comprehensive unit tests covering edge cases and real-world scenarios
- Enhance fqbn-utils.ts documentation with GitHub issue reference
- Bump version to 0.0.2

The new implementation:
- Parses runtime.platform.path to extract version directory name
- Falls back to version property if path extraction fails
- Handles cross-platform paths (macOS, Linux, Windows)
- Supports various version formats (semver, pre-release, custom suffixes)

Fixes: https://github.com/devista-consulting/arduino-sketch-vault/issues/1